### PR TITLE
6 implement menu logic

### DIFF
--- a/lib/page/settings/app_settings_service.dart
+++ b/lib/page/settings/app_settings_service.dart
@@ -24,14 +24,14 @@ class AppSettingsService {
       (e) => e.name == _prefs?.getString('instrument'),
       orElse: () => defaultSettings.instrument,
     );
-    final playingMode = PlayingMode.values.firstWhere(
-      (e) => e.name == _prefs?.getString('playingMode'),
-      orElse: () => defaultSettings.playingMode,
-    );
     final scale = Scale.values.firstWhere(
       (e) => e.name == _prefs?.getString('scale'),
       orElse: () => defaultSettings.scale,
     );
+    final playingMode = (scale.name != Scale.pentatonicMajor.name && scale.name != Scale.pentatonicMinor.name) ? (PlayingMode.values.firstWhere(
+      (e) => e.name == _prefs?.getString('playingMode'),
+      orElse: () => defaultSettings.playingMode,)) : PlayingMode.singleNote;
+    
 
     AppSettings settings = AppSettings(
       keyCentre: keyCenter,

--- a/lib/page/settings/app_settings_service.dart
+++ b/lib/page/settings/app_settings_service.dart
@@ -55,11 +55,22 @@ class AppSettingsService {
   }
 }
 
-// updatePlaymodeDrop (String selectedScale) {
-//   if (seletedPlaymode == '') {
+List<PlayingMode> updateModeDrop (Scale selectedScale) {
+  if (selectedScale.name == Scale.pentatonicMajor.name || selectedScale.name == Scale.pentatonicMinor.name) {
+    print('Compared selected Scale is $selectedScale.name');
+    print('2 Modes');
+    return PlayingMode.values.where((mode) => mode.name != 'Triad Chord').toList();
+  }
+  print('3 Modes');
+  return PlayingMode.values;
+}
 
-//   }
-// }
+PlayingMode updateModeSelect (Scale selectedScale, PlayingMode selectedPlayingMode) {
+  if (selectedScale.name == Scale.pentatonicMajor.name || selectedScale.name == Scale.pentatonicMinor.name) {
+    return (selectedPlayingMode.name == PlayingMode.triadChord.name) ? PlayingMode.singleNote : selectedPlayingMode;
+  }
+  return selectedPlayingMode;
+}
 
 const defaultSettings = AppSettings(
   keyCentre: KeyCentre.cNat,

--- a/lib/page/settings/settings_page.dart
+++ b/lib/page/settings/settings_page.dart
@@ -2,35 +2,45 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:music_app/page/settings/app_settings_model.dart';
 import 'package:music_app/page/settings/app_settings_notifier.dart';
+import 'package:music_app/page/settings/app_settings_service.dart';
 import 'package:music_app/special/enums.dart';
 
-class SettingsPage extends ConsumerWidget {
+class SettingsPage extends ConsumerStatefulWidget {
+  const SettingsPage({super.key});
+
+  @override
+  ConsumerState<SettingsPage> createState() => _SettingsPageState();
+}
+
+
+class _SettingsPageState extends ConsumerState<SettingsPage> {
   late Instrument selectedInstrument;
   late KeyCentre selectedKeyCentre;
   late Octave selectedOctave;
   late Scale selectedScale;
   late PlayingMode selectedPlayingMode;
 
-  late List<Instrument> dropdownInstruments;
-  late List<KeyCentre> dropdownKeys;
-  late List<Octave> dropdownOctaves;
-  late List<Scale> dropdownScales;
-  late List<PlayingMode> dropdownPlayingModes;
-
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final appSettings = ref.watch(appSettingsProvider);
+  void initState() {
+    super.initState();  
+    final appSettings = ref.read(appSettingsProvider);
     selectedInstrument = appSettings.instrument;
     selectedKeyCentre = appSettings.keyCentre;
     selectedOctave = appSettings.octave;
     selectedScale = appSettings.scale;
     selectedPlayingMode = appSettings.playingMode;
+  }
 
-    dropdownInstruments = Instrument.values;
-    dropdownKeys = KeyCentre.values;
-    dropdownOctaves = Octave.values;
-    dropdownScales = Scale.values;
-    dropdownPlayingModes = PlayingMode.values;
+  @override
+  Widget build(BuildContext context) {
+
+    List<Instrument> dropdownInstruments = Instrument.values;
+    List<KeyCentre> dropdownKeys = KeyCentre.values;
+    List<Octave> dropdownOctaves = Octave.values;
+    List<Scale> dropdownScales = Scale.values;
+    List<PlayingMode> dropdownPlayingModes = updateModeDrop(selectedScale);
+
+    selectedPlayingMode = updateModeSelect(selectedScale, selectedPlayingMode);
 
     return Scaffold(
       appBar: AppBar(
@@ -55,7 +65,9 @@ class SettingsPage extends ConsumerWidget {
                               ))
                           .toList(),
                       onChanged: (newValue) {
-                        selectedInstrument = newValue!;
+                        setState(() {
+                          selectedInstrument = newValue!;
+                        });
                       },
                     ),
                     SizedBox(height: 16),
@@ -69,7 +81,9 @@ class SettingsPage extends ConsumerWidget {
                               ))
                           .toList(),
                       onChanged: (newValue) {
-                        selectedKeyCentre = newValue!;
+                        setState(() {
+                          selectedKeyCentre = newValue!;
+                        });
                       },
                     ),
                     SizedBox(height: 16),
@@ -83,7 +97,11 @@ class SettingsPage extends ConsumerWidget {
                               ))
                           .toList(),
                       onChanged: (newValue) {
+                        setState(() {
+                          
+                        });
                         selectedScale = newValue!;
+                        selectedPlayingMode = updateModeSelect(selectedScale, selectedPlayingMode);
                       },
                     ),
                     SizedBox(height: 16),
@@ -97,7 +115,11 @@ class SettingsPage extends ConsumerWidget {
                               ))
                           .toList(),
                       onChanged: (newValue) {
-                        selectedOctave = newValue!;
+                        setState((){
+                          setState((){
+                            selectedOctave = newValue!;
+                          });
+                        });
                       },
                     ),
                     SizedBox(height: 16),
@@ -111,7 +133,9 @@ class SettingsPage extends ConsumerWidget {
                               ))
                           .toList(),
                       onChanged: (newValue) {
-                        selectedPlayingMode = newValue!;
+                        setState((){
+                          selectedPlayingMode = newValue!;
+                        });
                       },
                     ),
                     SizedBox(height: 32),

--- a/lib/page/settings/settings_page.dart
+++ b/lib/page/settings/settings_page.dart
@@ -98,10 +98,9 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                           .toList(),
                       onChanged: (newValue) {
                         setState(() {
-                          
+                          selectedScale = newValue!;
+                          selectedPlayingMode = updateModeSelect(selectedScale, selectedPlayingMode);
                         });
-                        selectedScale = newValue!;
-                        selectedPlayingMode = updateModeSelect(selectedScale, selectedPlayingMode);
                       },
                     ),
                     SizedBox(height: 16),


### PR DESCRIPTION
Changes:
- Added two new methods in settings service to read and update selected and dropdowns of playing mode according to scale. 
- Switched the .watch() for .read() and added back setState() for UI settings (to avoid using providers for ephemeral state (the selected values and dropdown values).
- Changed settings widget from stateless to stateful to reflect the need for the app to change its own internal state (dropdown selections).

Things to note:
- Provider is initialised in the initstate() which is not best practice. I could not move it down to the beginning of the build as the selected variables require it to initialise their values. I also couldn't move both the provider initislisation and selected variable value initialisation down to the build as setStates will re-build the widget everything.